### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://amendeinhouse.visualstudio.com/379f3696-7225-4468-9f8a-639ff302ff6b/a692c86c-415e-4614-9fa7-59915a218680/_apis/work/boardbadge/9d274719-c2e9-4100-9e02-8d738578d350)](https://amendeinhouse.visualstudio.com/379f3696-7225-4468-9f8a-639ff302ff6b/_boards/board/t/a692c86c-415e-4614-9fa7-59915a218680/Microsoft.RequirementCategory)
 # hello-nginx
 Simple docker example


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#102](https://amendeinhouse.visualstudio.com/379f3696-7225-4468-9f8a-639ff302ff6b/_workitems/edit/102). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.